### PR TITLE
added versioning to workflow and added gh-actions to package-ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+      
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+  

--- a/.github/workflows/build-deploy-workflow.yml
+++ b/.github/workflows/build-deploy-workflow.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
  run:
-   uses: data-altinn-no/deploy-actions/.github/workflows/dan-deploy-flow.yml@main
+   uses: data-altinn-no/deploy-actions/.github/workflows/dan-deploy-flow.yml@d08132e
    with:
      artifact_name: 'dan-plugin-brreg' # Can be omitted, defaults to 'artifact'
      function_project_path: 'src/Dan.Plugin.Brreg'


### PR DESCRIPTION
### Description
<!--- What and why -->
dependabot needs versioning on workflow to be able to recomment packages to upgrade
### Documentation
- [x] Doc updated
