### PR TITLE
return both spouses for ektepakt

### DIFF
--- a/src/Dan.Plugin.Brreg/Ektepakt.cs
+++ b/src/Dan.Plugin.Brreg/Ektepakt.cs
@@ -89,17 +89,30 @@ namespace Nadobe.EvidenceSources.ES_BR
             {
                 Ektepakter = new List<EktepaktModel>()
             };
-
+            
+            
+            
             foreach (var a in input.ektepakt)
             {
+                var spouseNames = new List<string>();
+
+                // Collect all spouse names from all roles
+                foreach (var rolle in a.rolle)
+                {
+                    if (rolle?.person?.navn != null)
+                    {
+                        var name = rolle.person.navn.fornavn + " "
+                                   + (string.IsNullOrEmpty(rolle.person.navn.mellomnavn)
+                                       ? ""
+                                       : rolle.person.navn.mellomnavn + " ")
+                                   + rolle.person.navn.etternavn;
+                        spouseNames.Add(name);
+                    }
+                }
+
                 var item = new EktepaktModel()
                 {
-                    SpouseName = a.rolle[1].person.navn.fornavn + " "
-                                //middlename if there is one
-                                + (string.IsNullOrEmpty(a.rolle[1].person.navn.mellomnavn)
-                                ? ""
-                                : a.rolle[1].person.navn.mellomnavn + " ")
-                          + a.rolle[1].person.navn.etternavn,
+                    SpouseNames = spouseNames,
                     EntryDate = a.innkomsttidspunkt
                 };
 

--- a/src/Dan.Plugin.Brreg/Ektepakt.cs
+++ b/src/Dan.Plugin.Brreg/Ektepakt.cs
@@ -88,15 +88,13 @@ namespace Nadobe.EvidenceSources.ES_BR
             var response = new EktepaktResponse()
             {
                 Ektepakter = new List<EktepaktModel>()
-            };
-            
-            
+            };                       
             
             foreach (var a in input.ektepakt)
             {
                 var spouseNames = new List<string>();
 
-                // Collect all spouse names from all roles
+                // Collect names for all roles that have a person name
                 foreach (var rolle in a.rolle)
                 {
                     if (rolle?.person?.navn != null)

--- a/src/Dan.Plugin.Brreg/Models/EktepaktModel.cs
+++ b/src/Dan.Plugin.Brreg/Models/EktepaktModel.cs
@@ -6,7 +6,7 @@ namespace Dan.Plugin.Brreg.Models
 {
     public class EktepaktModel
     {
-        public string SpouseName { get; set; }
+        public List<string> SpouseNames { get; set; }
 
         public DateTime? EntryDate { get; set; }
     }

--- a/test/Dan.Plugin.Brreg.Test/Ektepakttest.cs
+++ b/test/Dan.Plugin.Brreg.Test/Ektepakttest.cs
@@ -64,7 +64,7 @@ namespace Dan.Plugin.Brreg.Test
             var mapped = _ektepakt.MapEktepaktDD(input);
 
             //Assert
-            mapped.Ektepakter[0].SpouseName.Should().Be(expected);
+            mapped.Ektepakter[0].SpouseNames.Should().Contain(expected);
         }
     }
 }


### PR DESCRIPTION
### Description
<!--- What and why -->
Return both spouses when retreving ektepakt.

### Documentation
- [x] Doc updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced spouse data handling to capture all spouse names from records instead of limiting to a single entry.
* **Tests**
  * Updated tests to verify the presence of expected spouse names within the collection of names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->