### PR TITLE
added case for when there is only one rolle

### DIFF
--- a/src/Dan.Plugin.Brreg/Ektepakt.cs
+++ b/src/Dan.Plugin.Brreg/Ektepakt.cs
@@ -89,24 +89,30 @@ namespace Nadobe.EvidenceSources.ES_BR
             {
                 Ektepakter = new List<EktepaktModel>()
             };                       
-            
+
             foreach (var a in input.ektepakt)
             {
                 var spouseNames = new List<string>();
 
-                // Collect names for all roles that have a person name
-                foreach (var rolle in a.rolle)
+                if (a.rolle?.Length > 1)
                 {
-                    if (rolle?.person?.navn != null)
+                    foreach (var rolle in a.rolle)
                     {
                         var name = rolle.person.navn.fornavn + " "
-                                   + (string.IsNullOrEmpty(rolle.person.navn.mellomnavn)
-                                       ? ""
-                                       : rolle.person.navn.mellomnavn + " ")
-                                   + rolle.person.navn.etternavn;
+                                    + (string.IsNullOrEmpty(rolle.person.navn.mellomnavn)
+                                        ? ""
+                                        : rolle.person.navn.mellomnavn + " ")
+                                    + rolle.person.navn.etternavn;
                         spouseNames.Add(name);
                     }
                 }
+                else
+                {
+                    string name = a.paategning?
+                        .Select(p => p?.ToString())
+                        .FirstOrDefault(p => p != null && p.Contains("Ektefelle: "))
+                        ?.Replace("Ektefelle: ", "") ?? "";
+                }                
 
                 var item = new EktepaktModel()
                 {

--- a/src/Dan.Plugin.Brreg/Ektepakt.cs
+++ b/src/Dan.Plugin.Brreg/Ektepakt.cs
@@ -94,25 +94,31 @@ namespace Nadobe.EvidenceSources.ES_BR
             {
                 var spouseNames = new List<string>();
 
-                if (a.rolle?.Length > 1)
+                if (a.rolle?.Length >= 1)
                 {
                     foreach (var rolle in a.rolle)
                     {
-                        var name = rolle.person.navn.fornavn + " "
-                                    + (string.IsNullOrEmpty(rolle.person.navn.mellomnavn)
-                                        ? ""
-                                        : rolle.person.navn.mellomnavn + " ")
-                                    + rolle.person.navn.etternavn;
+                        var navn = rolle?.person.navn;
+                        if (navn == null)
+                            continue;
+                        
+                        var name = navn.fornavn
+                            + (string.IsNullOrEmpty(navn.mellomnavn) ? "" : " " + navn.mellomnavn)
+                            + " " + navn.etternavn;
                         spouseNames.Add(name);
                     }
                 }
-                else
+                if(spouseNames.Count < 2)
                 {
-                    string name = a.paategning?
+                    var name = a.paategning?
                         .Select(p => p?.ToString())
                         .FirstOrDefault(p => p != null && p.Contains("Ektefelle: "))
-                        ?.Replace("Ektefelle: ", "") ?? "";
-                }                
+                        ?.Replace("Ektefelle: ", "");
+                    if (!string.IsNullOrWhiteSpace(name) && !spouseNames.Contains(name))
+                    {
+                        spouseNames.Add(name);
+                    }
+                }
 
                 var item = new EktepaktModel()
                 {

--- a/test/Dan.Plugin.Brreg.Test/Ektepakttest.cs
+++ b/test/Dan.Plugin.Brreg.Test/Ektepakttest.cs
@@ -37,7 +37,6 @@ namespace Dan.Plugin.Brreg.Test
                 new Models.EktepaktV2.Ektepakt{
                     rolle =
                     [
-                        new Rolle(),
                         new Rolle
                         {
                             person = new Person()


### PR DESCRIPTION
### Description
<!--- What and why -->
Get both spouses

### Documentation
- [x] Doc updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spouse-name extraction: now conditionally collects valid person names (including middle names when present), avoids null/empty entries, and deduplicates results.
  * Adds a fallback that derives a spouse name from annotation text when fewer than two names are found, trimming prefixes and ignoring blank or duplicate values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->