### PR TITLE
Replace products and services with brrg api

### DIFF
--- a/src/Dan.Plugin.Brreg/AnnualFinancialReport.cs
+++ b/src/Dan.Plugin.Brreg/AnnualFinancialReport.cs
@@ -206,11 +206,11 @@ namespace Nadobe.EvidenceSources.ES_BR
             string url = $"{_settings.RegnskapsregisteretUri}/regnskapsregisteret/regnskap/aarsregnskap/kopi/{organization}/aar";
 
             var response = await Requests.MakeRequest(url, _client,
-            _settings.RegnskapsregisteretUsername, _settings.RegnskapsregisteretPw,
-            HttpMethod.Get, _logger);
-            
-            var availableYears = JsonConvert.DeserializeObject<List<string>>(
-            JsonConvert.SerializeObject(response));
+                _settings.RegnskapsregisteretUsername, _settings.RegnskapsregisteretPw,
+                HttpMethod.Get, _logger);
+
+            List<string> availableYears = JsonConvert.DeserializeObject<List<string>>(
+                    JsonConvert.SerializeObject(response));            
 
             if (availableYears == null || !availableYears.Any())
             {

--- a/src/Dan.Plugin.Brreg/AnnualFinancialReport.cs
+++ b/src/Dan.Plugin.Brreg/AnnualFinancialReport.cs
@@ -205,22 +205,12 @@ namespace Nadobe.EvidenceSources.ES_BR
         {
             string url = $"{_settings.RegnskapsregisteretUri}/regnskapsregisteret/regnskap/aarsregnskap/kopi/{organization}/aar";
 
-            List<string> availableYears;
-            try
-            {
-                var response = await Requests.MakeRequest(url, _client,
-                    _settings.RegnskapsregisteretUsername, _settings.RegnskapsregisteretPw,
-                    HttpMethod.Get, _logger);
-
-                availableYears = JsonConvert.DeserializeObject<List<string>>(
-                    JsonConvert.SerializeObject(response));
-            }
-            catch
-            {
-                throw new EvidenceSourcePermanentClientException(
-                    Constants.ERROR_NO_REPORT_AVAILABLE,
-                    $"No financial reports are available for {organization}");
-            }
+            var response = await Requests.MakeRequest(url, _client,
+            _settings.RegnskapsregisteretUsername, _settings.RegnskapsregisteretPw,
+            HttpMethod.Get, _logger);
+            
+            var availableYears = JsonConvert.DeserializeObject<List<string>>(
+            JsonConvert.SerializeObject(response));
 
             if (availableYears == null || !availableYears.Any())
             {

--- a/src/Dan.Plugin.Brreg/AnnualFinancialReport.cs
+++ b/src/Dan.Plugin.Brreg/AnnualFinancialReport.cs
@@ -105,33 +105,7 @@ namespace Nadobe.EvidenceSources.ES_BR
 
             var organization = evidenceHarvesterRequest.SubjectParty.NorwegianOrganizationNumber;
 
-            string url = $"{_settings.RegnskapsregisteretUri}/regnskapsregisteret/regnskap/aarsregnskap/kopi/{organization}/{year}";
-
-            var requestMessage = new HttpRequestMessage(HttpMethod.Get, url);
-            requestMessage.Headers.Accept.Clear();
-            requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("*/*"));
-
-            if (!string.IsNullOrEmpty(_settings.RegnskapsregisteretUsername))
-            {
-                var authString = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{_settings.RegnskapsregisteretUsername}:{_settings.RegnskapsregisteretPw}"));
-                requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Basic", authString);
-            }
-
-            var apiResponse = await _client.SendAsync(requestMessage);
-
-            if (!apiResponse.IsSuccessStatusCode)
-            {
-                throw new EvidenceSourcePermanentClientException(
-                    Constants.ERROR_NO_REPORT_AVAILABLE,
-                    $"No PDF available for {organization} year {year}");
-            }
-
-            var pdfBytes = await apiResponse.Content.ReadAsByteArrayAsync();
-
-            var response = req.CreateResponse(System.Net.HttpStatusCode.OK);
-            response.Headers.Add("Content-Type", "application/pdf");
-            await response.Body.WriteAsync(pdfBytes);
-            return response;
+            return await EvidenceSourceResponse.CreateResponse(req, () => GetAnnualFinancialReportPdf(organization, year));
         }
 
         /// <summary>

--- a/src/Dan.Plugin.Brreg/AnnualFinancialReport.cs
+++ b/src/Dan.Plugin.Brreg/AnnualFinancialReport.cs
@@ -96,6 +96,13 @@ namespace Nadobe.EvidenceSources.ES_BR
 
             evidenceHarvesterRequest.TryGetParameter("Year", out string year);
 
+            if (string.IsNullOrEmpty(year) || !System.Text.RegularExpressions.Regex.IsMatch(year, @"^\d{4}$"))
+            {
+                throw new EvidenceSourcePermanentClientException(
+                    Constants.ERROR_NO_REPORT_AVAILABLE,
+                    "Year parameter is missing or invalid. Expected a 4-digit year.");
+            }
+
             var organization = evidenceHarvesterRequest.SubjectParty.NorwegianOrganizationNumber;
 
             string url = $"{_settings.RegnskapsregisteretUri}/regnskapsregisteret/regnskap/aarsregnskap/kopi/{organization}/{year}";

--- a/src/Dan.Plugin.Brreg/AnnualFinancialReport.cs
+++ b/src/Dan.Plugin.Brreg/AnnualFinancialReport.cs
@@ -1,7 +1,10 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
 using System.Threading.Tasks;
 using Dan.Plugin.Brreg.Config;
 using Microsoft.Azure.Functions.Worker;
@@ -83,6 +86,45 @@ namespace Nadobe.EvidenceSources.ES_BR
             var organization = evidenceHarvesterRequest.SubjectParty.NorwegianOrganizationNumber;
 
             return await EvidenceSourceResponse.CreateResponse(req, () => GetAnnualFinancialReports(organization, numberOfYears));
+        }
+
+        [Function("AnnualFinancialReportPdf")]
+        public async Task<HttpResponseData> RunPdfAsync([HttpTrigger(AuthorizationLevel.Function, "post")] HttpRequestData req, FunctionContext context)
+        {
+            string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
+            var evidenceHarvesterRequest = JsonConvert.DeserializeObject<EvidenceHarvesterRequest>(requestBody);
+
+            evidenceHarvesterRequest.TryGetParameter("Year", out string year);
+
+            var organization = evidenceHarvesterRequest.SubjectParty.NorwegianOrganizationNumber;
+
+            string url = $"{_settings.RegnskapsregisteretUri}/regnskapsregisteret/regnskap/aarsregnskap/kopi/{organization}/{year}";
+
+            var requestMessage = new HttpRequestMessage(HttpMethod.Get, url);
+            requestMessage.Headers.Accept.Clear();
+            requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("*/*"));
+
+            if (!string.IsNullOrEmpty(_settings.RegnskapsregisteretUsername))
+            {
+                var authString = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{_settings.RegnskapsregisteretUsername}:{_settings.RegnskapsregisteretPw}"));
+                requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Basic", authString);
+            }
+
+            var apiResponse = await _client.SendAsync(requestMessage);
+
+            if (!apiResponse.IsSuccessStatusCode)
+            {
+                throw new EvidenceSourcePermanentClientException(
+                    Constants.ERROR_NO_REPORT_AVAILABLE,
+                    $"No PDF available for {organization} year {year}");
+            }
+
+            var pdfBytes = await apiResponse.Content.ReadAsByteArrayAsync();
+
+            var response = req.CreateResponse(System.Net.HttpStatusCode.OK);
+            response.Headers.Add("Content-Type", "application/pdf");
+            await response.Body.WriteAsync(pdfBytes);
+            return response;
         }
 
         /// <summary>
@@ -199,6 +241,93 @@ namespace Nadobe.EvidenceSources.ES_BR
                     }
                 }
             };
+        }
+        
+        public static EvidenceCode GetDefinitionPdf()
+        {
+            return new EvidenceCode
+            {
+                EvidenceCodeName = "AnnualFinancialReportPdf",
+                Description = "Returns the PDF for an annual financial report for a given year",
+                IsAsynchronous = false,
+                BelongsToServiceContexts = new List<string>() { Constants.EBEVIS, Constants.SERIOSITET, Constants.EDUEDILIGENCE },
+                Parameters = new List<EvidenceParameter>
+                {
+                    new EvidenceParameter
+                    {
+                        EvidenceParamName = "Year",
+                        ParamType = EvidenceParamType.String,
+                        Required = true
+                    }
+                },
+                Values = new List<EvidenceValue>
+                {
+                    new EvidenceValue
+                    {
+                        EvidenceValueName = "pdf",
+                        ValueType = EvidenceValueType.String,
+                        Source = Constants.SourceRegnskapsregisteret
+                    }
+                },
+                AuthorizationRequirements = new List<Requirement>()
+                {
+                    new PartyTypeRequirement()
+                    {
+                        AppliesToServiceContext = new List<string>() { Constants.EBEVIS, Constants.EDUEDILIGENCE },
+                        AllowedPartyTypes = new AllowedPartyTypesList()
+                        {
+                            new KeyValuePair<AccreditationPartyTypes, PartyTypeConstraint>(AccreditationPartyTypes.Requestor, PartyTypeConstraint.PublicAgency)
+                        }
+                    },
+                    new PartyTypeRequirement()
+                    {
+                        AppliesToServiceContext = new List<string>() { Constants.SERIOSITET },
+                        AllowedPartyTypes = new AllowedPartyTypesList()
+                        {
+                            new KeyValuePair<AccreditationPartyTypes, PartyTypeConstraint>(AccreditationPartyTypes.Requestor, PartyTypeConstraint.PrivateEnterprise)
+                        }
+                    },
+                    new AccreditationPartyRequirement()
+                    {
+                        AppliesToServiceContext = new List<string>() { Constants.EDUEDILIGENCE, Constants.SERIOSITET },
+                        PartyRequirements = new List<AccreditationPartyRequirementType>()
+                        {
+                            AccreditationPartyRequirementType.RequestorAndOwnerAreEqual
+                        }
+                    }
+                }
+            };
+        }
+
+        private async Task<List<EvidenceValue>> GetAnnualFinancialReportPdf(string organization, string year)
+        {
+            string url = $"{_settings.RegnskapsregisteretUri}/regnskapsregisteret/regnskap/aarsregnskap/kopi/{organization}/{year}";
+
+            var requestMessage = new HttpRequestMessage(HttpMethod.Get, url);
+            requestMessage.Headers.Accept.Clear();
+            requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("*/*"));
+
+            if (!string.IsNullOrEmpty(_settings.RegnskapsregisteretUsername))
+            {
+                var authString = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{_settings.RegnskapsregisteretUsername}:{_settings.RegnskapsregisteretPw}"));
+                requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Basic", authString);
+            }
+
+            var response = await _client.SendAsync(requestMessage);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new EvidenceSourcePermanentClientException(
+                    Constants.ERROR_NO_REPORT_AVAILABLE,
+                    $"No PDF available for {organization} year {year}");
+            }
+
+            var pdfBytes = await response.Content.ReadAsByteArrayAsync();
+
+            var eb = new EvidenceBuilder(_metadata, "AnnualFinancialReportPdf");
+            eb.AddEvidenceValue("pdf", Convert.ToBase64String(pdfBytes), Constants.SourceRegnskapsregisteret, false);
+
+            return eb.GetEvidenceValues();
         }
 
         private async Task<List<EvidenceValue>> GetAnnualFinancialReports(string organization, int numberOfYears)

--- a/src/Dan.Plugin.Brreg/AnnualFinancialReport.cs
+++ b/src/Dan.Plugin.Brreg/AnnualFinancialReport.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Dan.Plugin.Brreg.Config;
 using Microsoft.Azure.Functions.Worker;
@@ -16,6 +17,7 @@ using Dan.Common.Enums;
 using Dan.Common.Interfaces;
 using Dan.Plugin.Brreg;
 using Dan.Plugin.Brreg.Models;
+using Dan.Plugin.Brreg.Helpers;
 
 namespace Nadobe.EvidenceSources.ES_BR
 {
@@ -26,17 +28,18 @@ namespace Nadobe.EvidenceSources.ES_BR
     {
         private const int MIN_YEARS = 1;
         private const int MAX_YEARS = 5;
-        private const int REPORT_CODE = 3001;
 
         private readonly Settings _settings;
         private ILogger _logger;
         private readonly IEvidenceSourceMetadata _metadata;
+        private readonly HttpClient _client;
 
-        public AnnualFinancialReport(IOptions<Settings> settings, IEvidenceSourceMetadata evidenceSourceMetadata, ILoggerFactory loggerFactory)
+        public AnnualFinancialReport(IOptions<Settings> settings, IEvidenceSourceMetadata evidenceSourceMetadata, ILoggerFactory loggerFactory, IHttpClientFactory httpClientFactory)
         {
             _settings = settings.Value;
             _metadata = evidenceSourceMetadata;
             _logger = loggerFactory.CreateLogger<AnnualFinancialReport>();
+            _client = httpClientFactory.CreateClient("SafeHttpClient");
         }
 
         [Function("AnnualFinancialReport")]
@@ -57,18 +60,7 @@ namespace Nadobe.EvidenceSources.ES_BR
             }
 
             var organization = evidenceHarvesterRequest.SubjectParty.NorwegianOrganizationNumber;
-
-            return await EvidenceSourceResponse.CreateResponse(req, ()=> GetAnnualFinancialReports(organization, numberOfYears));
-        }
-
-        [Function("AnnualFinancialReportOpen")]
-        public async Task<HttpResponseData> AFROpen([HttpTrigger(AuthorizationLevel.Function, "post")] HttpRequestData req, FunctionContext context)
-        {
-            var requestBody = await new StreamReader(req.Body).ReadToEndAsync();
-            var evidenceHarvesterRequest = JsonConvert.DeserializeObject<EvidenceHarvesterRequest>(requestBody);
-            var organization = evidenceHarvesterRequest.SubjectParty.NorwegianOrganizationNumber;
-
-            return await EvidenceSourceResponse.CreateResponse(req, () => GetAnnualFinancialReports(organization, 3));
+            return await EvidenceSourceResponse.CreateResponse(req, () => GetAnnualFinancialReports(organization, numberOfYears));
         }
 
         [Function("Aarsregnskap")]
@@ -209,121 +201,48 @@ namespace Nadobe.EvidenceSources.ES_BR
             };
         }
 
-        public static EvidenceCode GetDefinitionOpen()
-        {
-            return new EvidenceCode
-            {
-                EvidenceCodeName = "AnnualFinancialReportOpen",
-                Description = "Code for retrieving URLs to PDFs for annual financial reports (1-5 years) synchronously",
-                IsAsynchronous = false,
-                BelongsToServiceContexts = new List<string>() { Constants.DIGOKFRIV },
-                IsPublic = true,
-                Parameters = new List<EvidenceParameter>
-                {
-                    new EvidenceParameter
-                    {
-                        EvidenceParamName = "NumberOfYears",
-                        ParamType = EvidenceParamType.Number,
-                        Required = true
-                    }
-                },
-                Values = new List<EvidenceValue>
-                {
-                    new EvidenceValue
-                    {
-                        EvidenceValueName = "Year1",
-                        ValueType = EvidenceValueType.String,
-                        Source = Constants.SourceEnhetsregisteret
-                    },
-                    new EvidenceValue
-                    {
-                        EvidenceValueName = "Year1PdfUrl",
-                        ValueType = EvidenceValueType.Uri,
-                        Source = Constants.SourceEnhetsregisteret
-                    },
-                    new EvidenceValue
-                    {
-                        EvidenceValueName = "Year2",
-                        ValueType = EvidenceValueType.String,
-                        Source = Constants.SourceEnhetsregisteret
-                    },
-                    new EvidenceValue
-                    {
-                        EvidenceValueName = "Year2PdfUrl",
-                        ValueType = EvidenceValueType.Uri,
-                        Source = Constants.SourceEnhetsregisteret
-                    },
-                    new EvidenceValue
-                    {
-                        EvidenceValueName = "Year3",
-                        ValueType = EvidenceValueType.String,
-                        Source = Constants.SourceEnhetsregisteret
-                    },
-                    new EvidenceValue
-                    {
-                        EvidenceValueName = "Year3PdfUrl",
-                        ValueType = EvidenceValueType.Uri,
-                        Source = Constants.SourceEnhetsregisteret
-                    },
-                    new EvidenceValue
-                    {
-                        EvidenceValueName = "Year4",
-                        ValueType = EvidenceValueType.String,
-                        Source = Constants.SourceEnhetsregisteret
-                    },
-                    new EvidenceValue
-                    {
-                        EvidenceValueName = "Year4PdfUrl",
-                        ValueType = EvidenceValueType.Uri,
-                        Source = Constants.SourceEnhetsregisteret
-                    },
-                    new EvidenceValue
-                    {
-                        EvidenceValueName = "Year5",
-                        ValueType = EvidenceValueType.String,
-                        Source = Constants.SourceEnhetsregisteret
-                    },
-                    new EvidenceValue
-                    {
-                        EvidenceValueName = "Year5PdfUrl",
-                        ValueType = EvidenceValueType.Uri,
-                        Source = Constants.SourceEnhetsregisteret
-                    }
-                }
-            };
-        }
-
         private async Task<List<EvidenceValue>> GetAnnualFinancialReports(string organization, int numberOfYears)
         {
-            Product[] annualReports = await BRProductsService.GetProductList(organization, REPORT_CODE, _settings);
-            if (annualReports == null)
+            string url = $"{_settings.RegnskapsregisteretUri}/regnskapsregisteret/regnskap/aarsregnskap/kopi/{organization}/aar";
+
+            List<string> availableYears;
+            try
+            {
+                var response = await Requests.MakeRequest(url, _client,
+                    _settings.RegnskapsregisteretUsername, _settings.RegnskapsregisteretPw,
+                    HttpMethod.Get, _logger);
+
+                availableYears = JsonConvert.DeserializeObject<List<string>>(
+                    JsonConvert.SerializeObject(response));
+            }
+            catch
             {
                 throw new EvidenceSourcePermanentClientException(
                     Constants.ERROR_NO_REPORT_AVAILABLE,
                     $"No financial reports are available for {organization}");
             }
 
-            Product[] listToBeOrdered =
-                (from t in annualReports where t.Code == REPORT_CODE orderby t.accountYear descending select t)
-                .Take(numberOfYears).ToArray();
-
-            if (!listToBeOrdered.Any())
+            if (availableYears == null || !availableYears.Any())
             {
                 throw new EvidenceSourcePermanentClientException(
                     Constants.ERROR_NO_REPORT_AVAILABLE,
                     $"No financial reports are available for {organization}");
             }
 
-            OrderedProduct[] orderResult = await BRProductsService.OrderProducts(organization, listToBeOrdered, _settings);
+            var yearsToReturn = availableYears
+                .OrderByDescending(y => y)
+                .Take(numberOfYears)
+                .ToList();
 
             var eb = new EvidenceBuilder(_metadata, nameof(AnnualFinancialReport));
 
-            for (int i = 0; i < orderResult.Length; i++)
+            for (int i = 0; i < yearsToReturn.Count; i++)
             {
-                eb.AddEvidenceValue($"Year{i + 1}", orderResult[i].AccountYear);
-                eb.AddEvidenceValue($"Year{i + 1}PdfUrl", orderResult[i].Url);
+                string year = yearsToReturn[i];
+                string pdfUrl = $"{_settings.RegnskapsregisteretUri}/regnskapsregisteret/regnskap/aarsregnskap/kopi/{organization}/{year}";
+                eb.AddEvidenceValue($"Year{i + 1}", year);
+                eb.AddEvidenceValue($"Year{i + 1}PdfUrl", pdfUrl);
             }
-
             return eb.GetEvidenceValues();
         }
     }

--- a/src/Dan.Plugin.Brreg/Metadata.cs
+++ b/src/Dan.Plugin.Brreg/Metadata.cs
@@ -43,6 +43,7 @@ namespace Nadobe.EvidenceSources.ES_BR {
             {
                 CertificateOfRegistration.GetDefinition(),
                 AnnualFinancialReport.GetDefinition(),
+                AnnualFinancialReport.GetDefinitionPdf(),
                 UnitBasicInformation.GetDefinition(),
                 Konkurs.GetDefinition(),
                 Regnskapsregisteret.GetDefinitionRegnskap(),
@@ -51,7 +52,6 @@ namespace Nadobe.EvidenceSources.ES_BR {
                 Kunngjoringer.GetDefinition(),
                 Ektepakt.GetDefinitionEktepaktV2(),
                 Losore.GetDefinitionRettsstiftelserKjoretoy(),
-                //Losore.GetDefinitionRettsstiftelserPerson(),
                 Losore.GetDefinitionRettsstiftelserVirksomhet(),
                 Stotteregisteret.GetDefinition(),
                 Tilskuddsregisteret.GetDefinition(),

--- a/src/Dan.Plugin.Brreg/Metadata.cs
+++ b/src/Dan.Plugin.Brreg/Metadata.cs
@@ -42,14 +42,11 @@ namespace Nadobe.EvidenceSources.ES_BR {
             return new List<EvidenceCode>
             {
                 CertificateOfRegistration.GetDefinition(),
-                //CertificateOfRegistration.GetDefinitionOpen(),
                 AnnualFinancialReport.GetDefinition(),
-                //AnnualFinancialReport.GetDefinitionOpen(),
-                UnitBasicInformation.GetDefinition(),              
-                Konkurs.GetDefinition(),               
+                UnitBasicInformation.GetDefinition(),
+                Konkurs.GetDefinition(),
                 Regnskapsregisteret.GetDefinitionRegnskap(),
                 Regnskapsregisteret.GetDefinitionRegnskapId(),
-                //Regnskapsregisteret.GetDefinitionRegnskapOpen(),
                 Roller.GetDefinition(),
                 Kunngjoringer.GetDefinition(),
                 Ektepakt.GetDefinitionEktepaktV2(),
@@ -59,7 +56,6 @@ namespace Nadobe.EvidenceSources.ES_BR {
                 Stotteregisteret.GetDefinition(),
                 Tilskuddsregisteret.GetDefinition(),
                 Registerutskrift.GetDefinition(),
-                //Losore.GetDefinitionRettsstiftelserVirksomhetOpen(),
                 Frivillighetsregisteret.GetDefinitionFrivilligOrganisation(),
                 UnitBasicInformation.GetDefinitionVirksomhetsinformasjon(),
             };

--- a/src/Dan.Plugin.Brreg/Regnskapsregisteret.cs
+++ b/src/Dan.Plugin.Brreg/Regnskapsregisteret.cs
@@ -45,15 +45,6 @@ namespace ES_BR
             return await EvidenceSourceResponse.CreateResponse(req, () => GetRegnskap(evidenceHarvesterRequest.SubjectParty.NorwegianOrganizationNumber, aar, type));
         }
 
-        [Function("RegnskapsregisteretOpen")]
-        public async Task<HttpResponseData> RRAccountsOpen([HttpTrigger(AuthorizationLevel.Function, "post")] HttpRequestData req, FunctionContext context)
-        {
-            _logger = context.GetLogger(context.FunctionDefinition.Name);
-            string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
-            var evidenceHarvesterRequest = JsonConvert.DeserializeObject<EvidenceHarvesterRequest>(requestBody);
-            return await EvidenceSourceResponse.CreateResponse(req, () => GetRegnskap(evidenceHarvesterRequest.SubjectParty.NorwegianOrganizationNumber, DateTime.Now.Year-1, "SELSKAP"));
-        }
-
         [Function("RegnskapsregisteretId")]
         public async Task<HttpResponseData> RRById([HttpTrigger(AuthorizationLevel.Function, "post")] HttpRequestData req, FunctionContext context)
         {
@@ -158,30 +149,5 @@ namespace ES_BR
             };
         }
 
-        public static EvidenceCode GetDefinitionRegnskapOpen()
-        {
-
-            return new EvidenceCode()
-            {
-                EvidenceCodeName = "RegnskapsregisteretOpen",
-                Description = "The public accounts of an organization",
-                BelongsToServiceContexts = new List<string>() { Constants.DIGOKFRIV },
-                IsPublic = true,
-                Values = new List<EvidenceValue>
-                {
-                    new EvidenceValue()
-                    {
-                        EvidenceValueName = "default",
-                        ValueType = EvidenceValueType.JsonSchema,
-                        Source = Constants.SourceRegnskapsregisteret
-                    }
-                },                
-                Parameters = new List<EvidenceParameter>()
-                {
-                    new EvidenceParameter() { EvidenceParamName = "Aar", ParamType = EvidenceParamType.Number, Required = true },
-                    new EvidenceParameter() { EvidenceParamName = "Type", ParamType = EvidenceParamType.String, Required = true },
-                }
-            };
-        }
     }
 }


### PR DESCRIPTION
### Description
<!--- What and why -->
Replace products and services lookup with brønnøysund api when fetching annual financial resports and årsregnskap
### Documentation
- [x] Doc updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a dedicated Annual Financial Report PDF endpoint for downloading a specific year’s report.
  * Extended available evidence codes to include PDF-based annual financial report data.

* **Refactor**
  * Improved annual financial report retrieval by using the Regnskapsregisteret “years” list to generate year-specific evidence (including PDF URLs).

* **Breaking Changes**
  * Removed the open/public Annual Financial Report endpoint.
  * Removed the open/public Regnskapsregisteret endpoint and its related evidence definition.

* **Documentation**
  * Updated evidence-code listing formatting and entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->