### PR TITLE
udpate schema generation and adde NLOD license to datasets

### DIFF
--- a/src/Dan.Plugin.Brreg/AnnualFinancialReport.cs
+++ b/src/Dan.Plugin.Brreg/AnnualFinancialReport.cs
@@ -218,6 +218,7 @@ namespace Nadobe.EvidenceSources.ES_BR
                 IsAsynchronous = false,
                 BelongsToServiceContexts = new List<string>() { Constants.DIGOKFRIV },
                 IsPublic = true,
+                License = "https://data.norge.no/nlod/no/2.0/",
                 Parameters = new List<EvidenceParameter>
                 {
                     new EvidenceParameter

--- a/src/Dan.Plugin.Brreg/CertificateOfRegistration.cs
+++ b/src/Dan.Plugin.Brreg/CertificateOfRegistration.cs
@@ -140,6 +140,7 @@ namespace Dan.Plugin.Brreg {
                 Description = "Code for retrieving URL to a PDF for the certificate of registration",
                 BelongsToServiceContexts = new List<string>() { Constants.DIGOKFRIV },
                 IsPublic = true,
+                License = "https://data.norge.no/nlod/no/2.0/",
                 Values = new List<EvidenceValue>
                 {
                     new EvidenceValue()

--- a/src/Dan.Plugin.Brreg/Ektepakt.cs
+++ b/src/Dan.Plugin.Brreg/Ektepakt.cs
@@ -23,7 +23,6 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using Dan.Plugin.Brreg.Helpers;
 using Dan.Plugin.Brreg.Models.EktepaktV2;
-using NJsonSchema;
 
 
 namespace Nadobe.EvidenceSources.ES_BR
@@ -146,7 +145,8 @@ namespace Nadobe.EvidenceSources.ES_BR
                         EvidenceValueName = "default",
                         Source = Constants.SourceLosoreregisteret,
                         ValueType = EvidenceValueType.JsonSchema,
-                        Description = $"Json payload from {Constants.SourceLosoreregisteret}"
+                        Description = $"Json payload from {Constants.SourceLosoreregisteret}",
+                        JsonSchemaDefintion = EvidenceValue.SchemaFromObject<EktepaktResponse>(Formatting.None)
                     }
                 }
             };

--- a/src/Dan.Plugin.Brreg/Frivillighetsregisteret.cs
+++ b/src/Dan.Plugin.Brreg/Frivillighetsregisteret.cs
@@ -63,6 +63,7 @@ namespace Dan.Plugin.Brreg
                 BelongsToServiceContexts = new List<string>() { Constants.DIGOKFRIV },
                 Description = $"Hente en organisasjon fra {Constants.SourceFrivillighetsregisteret}",
                 IsPublic = true,
+                License = "https://data.norge.no/nlod/no/2.0/",
                 EvidenceSource = "Brreg",
                 Values = new List<EvidenceValue>()
                 {

--- a/src/Dan.Plugin.Brreg/Kunngjoringer.cs
+++ b/src/Dan.Plugin.Brreg/Kunngjoringer.cs
@@ -57,6 +57,7 @@ namespace Dan.Plugin.Brreg
                 EvidenceCodeName = "Kunngjoringer",
                 BelongsToServiceContexts = new List<string>() { Constants.EDUEDILIGENCE, Constants.DIGOKFRIV },
                 IsPublic = true,
+                License = "https://data.norge.no/nlod/no/2.0/",
                 Values = new List<EvidenceValue>()
                 {
                     new EvidenceValue()

--- a/src/Dan.Plugin.Brreg/Losore.cs
+++ b/src/Dan.Plugin.Brreg/Losore.cs
@@ -24,7 +24,6 @@ using Newtonsoft.Json;
 using Constants = Dan.Plugin.Brreg.Models.Constants;
 using StackExchange.Redis;
 using Azure;
-using NJsonSchema;
 
 namespace Dan.Plugin.Brreg
 {
@@ -135,7 +134,7 @@ namespace Dan.Plugin.Brreg
                         Source = Constants.SourceLosoreregisteret,
                         ValueType = EvidenceValueType.JsonSchema,
                         Description = $"Json payload from {Constants.SourceLosoreregisteret}",
-                        JsonSchemaDefintion =  JsonSchema.FromType<LosoreV2>().ToJson(Formatting.None),
+                        JsonSchemaDefintion =  EvidenceValue.SchemaFromObject<LosoreV2>(Formatting.None),
                     }
                 },
                 Parameters = new List<EvidenceParameter>()
@@ -185,7 +184,7 @@ namespace Dan.Plugin.Brreg
                         Source = Constants.SourceLosoreregisteret,
                         ValueType = EvidenceValueType.JsonSchema,
                         Description = $"Json payload from {Constants.SourceLosoreregisteret}",
-                        JsonSchemaDefintion = JsonSchema.FromType<LosoreV2>().ToJson(Formatting.None)
+                        JsonSchemaDefintion = EvidenceValue.SchemaFromObject<LosoreV2>(Formatting.None)
                     }
                 },
                 AuthorizationRequirements = new List<Requirement>()
@@ -210,6 +209,7 @@ namespace Dan.Plugin.Brreg
                 BelongsToServiceContexts = new List<string>() { Constants.DIGOKFRIV },
                 Description = "",
                 IsPublic = true,
+                License = "https://data.norge.no/nlod/no/2.0/",
                 EvidenceSource = "Brreg",
                 Values = new List<EvidenceValue>()
                 {
@@ -219,7 +219,7 @@ namespace Dan.Plugin.Brreg
                         Source = Constants.SourceLosoreregisteret,
                         ValueType = EvidenceValueType.JsonSchema,
                         Description = $"Json payload from {Constants.SourceLosoreregisteret}",
-                        JsonSchemaDefintion = JsonSchema.FromType<LosoreV2>().ToJson(Formatting.None)
+                        JsonSchemaDefintion = EvidenceValue.SchemaFromObject<LosoreV2>(Formatting.None)
                     }
                 }
             };
@@ -240,7 +240,7 @@ namespace Dan.Plugin.Brreg
                         Source = Constants.SourceLosoreregisteret,
                         ValueType = EvidenceValueType.JsonSchema,
                         Description = $"Json payload from {Constants.SourceLosoreregisteret}",
-                        JsonSchemaDefintion = JsonSchema.FromType<LosoreV2>().ToJson(Formatting.None)
+                        JsonSchemaDefintion = EvidenceValue.SchemaFromObject<LosoreV2>(Formatting.None)
                     }
                 },
                 AuthorizationRequirements = new List<Requirement>()

--- a/src/Dan.Plugin.Brreg/Registerutskrift.cs
+++ b/src/Dan.Plugin.Brreg/Registerutskrift.cs
@@ -67,6 +67,7 @@ namespace Dan.Plugin.Brreg {
                 Description = "Provides a URL to a PDF for the certificate of registration",
                 BelongsToServiceContexts = new List<string>() { Constants.DIGOKFRIV },
                 IsPublic = true,
+                License = "https://data.norge.no/nlod/no/2.0/",
                 Values = new List<EvidenceValue>
                 {
                     new EvidenceValue()

--- a/src/Dan.Plugin.Brreg/Regnskapsregisteret.cs
+++ b/src/Dan.Plugin.Brreg/Regnskapsregisteret.cs
@@ -167,6 +167,7 @@ namespace ES_BR
                 Description = "The public accounts of an organization",
                 BelongsToServiceContexts = new List<string>() { Constants.DIGOKFRIV },
                 IsPublic = true,
+                License = "https://data.norge.no/nlod/no/2.0/",
                 Values = new List<EvidenceValue>
                 {
                     new EvidenceValue()

--- a/src/Dan.Plugin.Brreg/Roller.cs
+++ b/src/Dan.Plugin.Brreg/Roller.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using NJsonSchema;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -163,7 +162,7 @@ namespace Dan.Plugin.Brreg
                     {
                         EvidenceValueName = "default",
                         ValueType = EvidenceValueType.JsonSchema,
-                        JsonSchemaDefintion = JsonSchema.FromType<RollerResponse>().ToJson(Formatting.None),
+                        JsonSchemaDefintion = EvidenceValue.SchemaFromObject<RollerResponse>(Formatting.None),
                         Source = Constants.SourceEnhetsregisteret
                     }
                 },

--- a/src/Dan.Plugin.Brreg/Stotteregisteret.cs
+++ b/src/Dan.Plugin.Brreg/Stotteregisteret.cs
@@ -57,6 +57,7 @@ namespace Dan.Plugin.Brreg
                 EvidenceCodeName = "StotteregisteretUrl",
                 BelongsToServiceContexts = new List<string>() { Constants.DIGOKFRIV },
                 IsPublic = true,
+                License = "https://data.norge.no/nlod/no/2.0/",
                 Values = new List<EvidenceValue>()
                 {
                     new EvidenceValue()

--- a/src/Dan.Plugin.Brreg/Tilskuddsregisteret.cs
+++ b/src/Dan.Plugin.Brreg/Tilskuddsregisteret.cs
@@ -57,6 +57,7 @@ namespace Dan.Plugin.Brreg
                 EvidenceCodeName = "TilskuddsregisteretUrl",
                 BelongsToServiceContexts = new List<string>() { Constants.DIGOKFRIV },
                 IsPublic = true,
+                License = "https://data.norge.no/nlod/no/2.0/",
                 Values = new List<EvidenceValue>()
                 {
                     new EvidenceValue()

--- a/src/Dan.Plugin.Brreg/UnitBasicInformation.cs
+++ b/src/Dan.Plugin.Brreg/UnitBasicInformation.cs
@@ -113,6 +113,7 @@ namespace Nadobe.EvidenceSources.ES_BR
                 Description = "Return units basic information for the subject company",
                 BelongsToServiceContexts = new List<string>() { Constants.EBEVIS, Constants.EDUEDILIGENCE, Constants.SERIOSITET, Constants.DIGOKFRIV, Constants.ALTINNSTUDIOAPPS },
                 IsPublic = true,
+                License = "https://data.norge.no/nlod/no/2.0/",
                 Values = new List<EvidenceValue>
                 {
                     new EvidenceValue()


### PR DESCRIPTION
### Description
<!--- What and why -->
update schema generation and added NLOD license to datasets
### Documentation
- [x] Doc updated
- [ ] Tested


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Norwegian License for Open Government Data metadata to Brønnøysund Register Centre evidence definitions.
  * Improved JSON schema generation for selected registration and financial response data.
* **Documentation**
  * Evidence definitions now clearly identify the applicable data license, helping users understand usage and reuse terms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->